### PR TITLE
Remove pendulum_launch.bash from the test cases for Jazzy.

### DIFF
--- a/config/jazzy/requirements/features-executable.yaml
+++ b/config/jazzy/requirements/features-executable.yaml
@@ -308,9 +308,6 @@ requirements:
       - name: Check `pendulum_teleop`
         try:
           - stdin: ros2 run pendulum_control pendulum_teleop
-      - name: Check `pendulum_launch.bash`
-        try:
-          - stdin: ros2 launch pendulum_control pendulum_launch.bash
       - name: Check `pendulum_logger`
         try:
           - stdin: ros2 run pendulum_control pendulum_logger


### PR DESCRIPTION
We removed this in the upstream sources.

See https://github.com/ros2/demos/pull/624