### PR TITLE
Add in the "start_type_description_service" parameter.

### DIFF
--- a/config/jazzy/requirements/core.yaml
+++ b/config/jazzy/requirements/core.yaml
@@ -108,6 +108,7 @@ requirements:
                 qos_overrides./parameter_events.publisher.durability
                 qos_overrides./parameter_events.publisher.history
                 qos_overrides./parameter_events.publisher.reliability
+                start_type_description_service
                 use_sim_time
             terminal: 2
   - name: ros2cli network tests

--- a/config/jazzy/requirements/features-cli.yaml
+++ b/config/jazzy/requirements/features-cli.yaml
@@ -567,6 +567,7 @@ requirements:
                         durability: volatile
                         history: keep_last
                         reliability: reliable
+                  start_type_description_service: true
                   use_sim_time: false
       - name: Check get
         try:
@@ -597,6 +598,7 @@ requirements:
               qos_overrides./parameter_events.publisher.durability
               qos_overrides./parameter_events.publisher.history
               qos_overrides./parameter_events.publisher.reliability
+              start_type_description_service
               use_sim_time
       - name: Check set
         try:


### PR DESCRIPTION
This came in with Iron, but we never updated the configuration for it.  Add it here.